### PR TITLE
Fix Overall Score Dtype

### DIFF
--- a/src/chaiverse/metrics.py
+++ b/src/chaiverse/metrics.py
@@ -242,7 +242,7 @@ def _add_overall_rank(df):
     thumbs_up_rank = df['thumbs_up_ratio'].rank(ascending=False)
     df.loc[:, 'thumbs_up_rank'] = thumbs_up_rank
     df.loc[:, 'overall_score'] = np.mean([thumbs_up_rank], axis=0)
-    df.loc[:, 'overall_rank'] = df.overall_score.rank()
+    df['overall_rank'] = df.overall_score.rank().astype(float)
     return df
 
 


### PR DESCRIPTION
I tried to run the test and it seems that one test is failing due to overall_rank dtype is object. We should either remove the test or change the dtype in the code 
![image](https://github.com/chai-research/chaiverse/assets/26734897/23419b28-9f98-4b71-b4a8-6e0fa66098a5)
