### PR TITLE
fix: result of  _get_latest_feedback should be cached

### DIFF
--- a/src/chaiverse/feedback.py
+++ b/src/chaiverse/feedback.py
@@ -115,8 +115,8 @@ def _get_latest_feedback(submission_id, developer_key):
     resp = requests.get(url, headers=headers)
     assert resp.status_code == 200, resp.json()
     feedback = Feedback(resp.json())
+    utils._save_to_cache(Path(utils.guanaco_data_dir()) / 'cache' / f'{submission_id}.pkl', feedback)
     return feedback
-
 
 def _get_cached_feedback(submission_id, developer_key):
     filename = Path(utils.guanaco_data_dir()) / 'cache' / f'{submission_id}.pkl'

--- a/src/chaiverse/feedback.py
+++ b/src/chaiverse/feedback.py
@@ -118,6 +118,7 @@ def _get_latest_feedback(submission_id, developer_key):
     utils._save_to_cache(Path(utils.guanaco_data_dir()) / 'cache' / f'{submission_id}.pkl', feedback)
     return feedback
 
+
 def _get_cached_feedback(submission_id, developer_key):
     filename = Path(utils.guanaco_data_dir()) / 'cache' / f'{submission_id}.pkl'
     try:

--- a/tests/test_chaiverse/test_metrics.py
+++ b/tests/test_chaiverse/test_metrics.py
@@ -40,9 +40,10 @@ def test_developer_can_call_get_submission_metrics_and_pass_in_developer_key_as_
 
 @mock.patch('chaiverse.metrics.get_all_historical_submissions')
 @mock.patch('chaiverse.utils.guanaco_data_dir')
+@mock.patch('chaiverse.utils._save_to_cache')
 @freeze_time('2023-07-28 00:00:00')
 @vcr.use_cassette(os.path.join(RESOURCE_DIR, 'test_get_raw_leaderboard.yaml'))
-def test_get_raw_leaderboard(data_dir_mock, get_ids_mock, tmpdir):
+def test_get_raw_leaderboard(save_cache_mock, data_dir_mock, get_ids_mock, tmpdir):
     data_dir_mock.return_value = str(tmpdir)
     get_ids_mock.return_value = historical_submisions()
     df = chai.metrics.get_raw_leaderboard(max_workers=1, developer_key="key")

--- a/tests/test_chaiverse/test_metrics.py
+++ b/tests/test_chaiverse/test_metrics.py
@@ -15,6 +15,11 @@ RESOURCE_DIR = os.path.join(os.path.abspath(os.path.join(__file__, '..')), 'reso
 
 MAX_FILTERED_FEEDBACK_COUNT = 0
 
+@pytest.fixture(autouse="session")
+def mock_data_dir(tmpdir):
+    with patch.dict(os.environ, {'GUANACO_DATA_DIR': str(tmpdir)}):
+        yield
+
 @mock.patch('chaiverse.metrics.get_all_historical_submissions')
 def test_developer_can_call_display_leaderboard_and_pass_in_developer_key_as_arg(get_submissions_mock):
     get_submissions_mock.side_effect = KeyError()
@@ -40,12 +45,9 @@ def test_developer_can_call_get_submission_metrics_and_pass_in_developer_key_as_
 
 
 @mock.patch('chaiverse.metrics.get_all_historical_submissions')
-@mock.patch('chaiverse.utils.guanaco_data_dir')
-@mock.patch('chaiverse.utils._save_to_cache')
 @freeze_time('2023-07-28 00:00:00')
 @vcr.use_cassette(os.path.join(RESOURCE_DIR, 'test_get_raw_leaderboard.yaml'))
-def test_get_raw_leaderboard(save_cache_mock, data_dir_mock, get_ids_mock, tmpdir):
-    data_dir_mock.return_value = str(tmpdir)
+def test_get_raw_leaderboard(get_ids_mock):
     get_ids_mock.return_value = historical_submisions()
     df = chai.metrics.get_raw_leaderboard(max_workers=1, developer_key="key")
     expected_cols = [


### PR DESCRIPTION
I just added a line to fix this. I'll add a few tests if you guys think this is good, or if some refactoring is needed since I think the Except part of _get_cached_feedback will never be called.

(2nd run after the fix, this is good for spamming the leaderboard to view the latest update every few minutes, and would save chai a lot of money since only changed models got pulled)
<img width="1440" alt="Screen Shot 2023-12-25 at 5 02 13 AM" src="https://github.com/chai-research/chaiverse/assets/26734897/77741977-9ac2-4fe5-bc3d-af7a92f74223">
