### PR TITLE
Bugs/leaderboard filter unique model

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/src/chaiverse/metrics/get_display_leaderboard.py
+++ b/src/chaiverse/metrics/get_display_leaderboard.py
@@ -62,7 +62,7 @@ def _get_model_size(num_parameters):
 
 
 def _get_submissions_with_unique_model(df):
-    df = df.drop_duplicates(subset=['model_repo', 'reward_repo'], keep='first')
+    df = df.drop_duplicates(subset=['developer_uid', 'model_repo', 'reward_repo'], keep='first')
     return df
 
 

--- a/tests/test_chaiverse/test_metrics/test_get_display_leaderboard.py
+++ b/tests/test_chaiverse/test_metrics/test_get_display_leaderboard.py
@@ -11,6 +11,7 @@ from chaiverse.metrics.get_display_leaderboard import (
     _get_isoformatted_timestamp,
     _get_model_size,
     _get_ranked_leaderboard,
+    _get_deduped_leaderboard,
     _sort,
 )
 
@@ -42,6 +43,20 @@ def test_get_ranked_leaderboard_will_sort_by_rank_for_same_model_repo_but_differ
     })
     result = _get_ranked_leaderboard(df, sort_params=dict(by='overall_rank'))
     assert list(result['submission_id']) == ['submission-2', 'submission-1']
+
+
+def test_get_ranked_leaderboard_will_sort_by_rank_for_same_model_repo_and_same_reward_repo_but_different_developer_uid_if_not_in_detailed_mode():
+    df = make_unique_submissions(4)
+    df.update({
+        'developer_uid': ['developer_uid-2', 'developer_uid-1', 'developer_uid-2', 'developer_uid-3'],
+        'submission_id': ['submission-2-bad', 'submission-1', 'submission-2-top2', 'submission-3-top1'],
+        'model_repo': ['mock-model-repo-bad', 'random-mock-model-repo', 'mock-model-repo', 'mock-model-repo'],
+        'reward_repo': ['mock-reward-repo-bad', 'random-mock-reward-repo', 'mock-reward-repo', 'mock-reward-repo'],
+        'stay_in_character': [1, 7, 8, 9]
+    })
+    result = _get_ranked_leaderboard(df, sort_params=dict(by='overall_rank'))
+    result = _get_deduped_leaderboard(result)
+    assert list(result['submission_id']) == ['submission-3-top1', 'submission-2-top2', 'submission-1']
 
 
 def test_get_isoformatted_timestamp():


### PR DESCRIPTION
For non-detailed leaderboard, it first ranks the submissions then filters unique models based on a combination of `model_repo` and `reward_repo`.  This fails on an edge case where more than one developer submit a same open-source LM and reward model (Chai's in-house model by default), resulting to the highest scored submission from these developers is counted.

For example, **khoangothe** is supposed to be at top 6 with his `jondurbin-nontoxic-bagel-34b_v15` submission. 
<img width="1328" alt="Screenshot 2024-01-26 at 9 18 07 PM" src="https://github.com/chai-research/chaiverse/assets/33384701/8844e040-661e-4cad-860d-8a3b6396d99d">
But since **Chenyue** has a better `jondurbin-nontoxic-bagel-34b_v17` submission also coming from `jondurbin/nontoxic-bagel-34b` model, all other developers (**khoangothe, decem_y, robert_irvine,...**) who submitted the same model get filtered out. As a result, the second-best non-jondurbin models from these developers are selected. In **khoangothe**'s case, he now places at top 18.
<img width="1290" alt="Screenshot 2024-01-26 at 9 15 51 PM" src="https://github.com/chai-research/chaiverse/assets/33384701/462f0392-e207-4d4a-add0-93b8569296ef">
