### PR TITLE
Bug: Fix JSON Format Error by Enhancing reward_formatter in _preprocess_submission

### DIFF
--- a/src/chaiverse/submit.py
+++ b/src/chaiverse/submit.py
@@ -71,8 +71,9 @@ class ModelSubmitter:
 
     def _preprocess_submission(self, submission_params):
         if submission_params.get("formatter", None):
-            submission_params = submission_params.copy()
             submission_params["formatter"] = submission_params["formatter"].dict()
+        if submission_params.get("reward_formatter", None):
+            submission_params["reward_formatter"] = submission_params["reward_formatter"].dict()
         return submission_params
 
     def _wait_for_model_submission(self, submission_id):


### PR DESCRIPTION
This PR updates the _preprocess_submission method to enable in-place conversion of the reward_formatter parameter into a dictionary. This modification prevents the occurrence of JSON format errors during model submission that arise from mishandling of the reward_formatter.