### PR TITLE
Bug: Fix issue with pydantic 2.x

### DIFF
--- a/src/chaiverse/requirements.txt
+++ b/src/chaiverse/requirements.txt
@@ -1,7 +1,7 @@
 click
 numpy
 pandas
-pydantic
+pydantic==1.*
 requests
 tqdm
 tabulate


### PR DESCRIPTION
This pull request addresses #13 a compatibility issue encountered when using the Chaiverse package alongside Pydantic version 2.x. As a temporary measure to ensure continued functionality for Chaiverse users, this PR pins the Pydantic version requirement to <2.0. This prevents the aforementioned error by avoiding the breaking changes introduced in Pydantic 2.x.
While this fix addresses the immediate issue, it is recognized as a temporary solution. A review and potential refactoring of Chaiverse's codebase is recommended to ensure compatibility with Pydantic version 2.x. This would involve adding appropriate type annotations to field overrides and reviewing Pydantic's updated best practices and features.


